### PR TITLE
Add package_source for installing from Rocket.Chat forks

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class rocketchat (
   $download_path  = $rocketchat::params::download_path,
   $destination    = $rocketchat::params::destination,
   $package_ensure = $rocketchat::params::package_ensure,
+  $package_source = $rocketchat::params::package_source,
   $mongo_host     = $rocketchat::params::mongo_host,
   $database_name  = $rocketchat::params::database_name,
   $mongo_port     = $rocketchat::params::mongo_port,
@@ -45,7 +46,8 @@ class rocketchat (
   class { 'rocketchat::install':
     download_path  => $download_path,
     destination    => $destination,
-    package_ensure => $package_ensure
+    package_ensure => $package_ensure,
+    package_source => $package_source
   }
 
   class { 'rocketchat::service':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,15 +1,21 @@
 class rocketchat::install(
   $download_path,
   $destination,
-  $package_ensure
+  $package_ensure,
+  $package_source,
 ) {
   include wget
   include apt
 
   $file_path = "${download_path}/rocket.tgz"
 
+  $source = $package_source ? {
+    undef   => "https://rocket.chat/releases/${package_ensure}/download",
+    default => "${package_source}/rocket.chat-${package_ensure}.tgz",
+  }
+
   wget::fetch { 'Download stable Rocket.Chat package':
-    source      => "https://rocket.chat/releases/${package_ensure}/download",
+    source      => $source,
     destination => $file_path,
     verbose     => false,
     before      => Archive[$file_path],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class rocketchat::params {
   $download_path  = '/tmp'
   $destination    = '/opt'
   $package_ensure = 'latest'
+  $package_source = undef
   $mongo_host     = 'localhost'
   $mongo_port     = 27017
   $mongo_replset  = undef

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -32,7 +32,8 @@ describe 'rocketchat' do
           is_expected.to contain_class('rocketchat::install').with(
             'download_path' => '/tmp',
             'destination'   => '/opt',
-            'package_ensure' => 'latest'
+            'package_ensure' => 'latest',
+            'package_source' => nil
            )
         end
 

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -14,7 +14,8 @@ describe 'rocketchat::packages' do
       "class { 'rocketchat::install':
         download_path => '/tmp',
         destination =>'/tmp',
-        package_ensure => 'latest'
+        package_ensure => 'latest',
+        package_source => undef
  }"
     }
 


### PR DESCRIPTION
This lets us use some FTP or S3 source of custom-built Rocket.Chat instead of the official releases.