### PR TITLE
Small fixes (deps and include)

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,6 @@ class rocketchat::install(
   $package_source,
 ) {
   include wget
-  include apt
 
   $file_path = "${download_path}/rocket.tgz"
 

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,8 @@
       {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0",
        "name":"puppetlabs-mongodb","version_requirement":">= 0.17.0",
        "name":"willdurand-nodejs","version_requirement":">= 2.0.0-alpha3",
-       "name":"maestrodev-wget","version_requirement":">=1.7.0"
+       "name":"maestrodev-wget","version_requirement":">=1.7.0",
+       "name":"puppet-archive", "version_requirement":">=1.3.0"
       }
   ],
     "operatingsystem_support": [


### PR DESCRIPTION
Hi there,

I tried to use this on RHEL and stumbled over the unused `include apt` which is obviously not available on RHEL.

While browsing the code I noticed the use of the defined type `archive`, which most certainly comes from "puppet-archive", which is not mentioned as a dep in metadata.json.

Hope this helps,
Cheers,
Oliver